### PR TITLE
Better fix for external access and port config

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -10,7 +10,4 @@ def hello():
     return "Hello World!"
 
 if __name__ == "__main__":
-    app.config.update(
-        SERVER_NAME='127.0.0.1:%d' % int(os.environ.get('PORT', 5000)),
-    )
-    app.run(host='0.0.0.0')
+    app.run(host='0.0.0.0', port='%d'  % int(os.environ.get('PORT', 5000)))


### PR DESCRIPTION
The SERVER NAME option seems to be akward for a localhost and demo version which override to a specific IP and port.
Seems better when using this configuration in the 'run' method to let the external access active and specifying a specific port.
